### PR TITLE
Add chapter display component and sample scenes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -37,6 +37,19 @@
       ]
     },
     {
+      "name": "d:チャプター付き10秒ムービー",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "audio2movie.py",
+      "console": "integratedTerminal",
+      "args": [
+        "./data/sample10.mp3",
+        "sample_chapters",
+        "./out/sample.mp4",
+        "--keep-work"
+      ]
+    },
+    {
       "name": "d:67秒ムービー",
       "type": "debugpy",
       "request": "launch",

--- a/template/assets/chapters.js
+++ b/template/assets/chapters.js
@@ -14,6 +14,23 @@ function convertSecondsToMs(secondsValue) {
 }
 
 /**
+ * シーン内時刻と音声開始オフセットから音源全体の再生時刻（ミリ秒）を求める
+ * @param {number|undefined} sceneMs シーン内の再生時刻（ミリ秒）
+ * @returns {number} 音源全体の再生時刻（ミリ秒）
+ */
+function getGlobalAudioTimeMs(sceneMs) {
+  const localMs = Number.isFinite(sceneMs)
+    ? sceneMs
+    : Number.isFinite(window.__AUDIO2MOVIE_TIME__)
+      ? window.__AUDIO2MOVIE_TIME__
+      : 0;
+  const startTimeSec = Number.isFinite(window.__AUDIO2MOVIE_AUDIO_START_TIME__)
+    ? window.__AUDIO2MOVIE_AUDIO_START_TIME__
+    : 0;
+  return localMs + (startTimeSec * 1000);
+}
+
+/**
  * application/json+chapters 形式のデータからチャプター配列を抽出する
  * @param {object|string} chaptersData チャプターデータ（オブジェクトまたはJSON文字列）
  * @returns {object[]} 正規化したチャプター配列
@@ -95,12 +112,12 @@ function renderChapter(chapter) {
 
 /**
  * 指定した再生時刻に一致するチャプターを検索して表示する
- * @param {number} ms 現在の再生位置（ミリ秒）
+ * @param {number} ms 現在のシーン再生位置（ミリ秒）
  */
 function updateChapterDisplay(ms) {
   if (!chapterDisplayElement || chapterList.length === 0) return;
 
-  const currentMs = Number.isFinite(ms) ? ms : (window.__AUDIO2MOVIE_TIME__ || 0);
+  const currentMs = getGlobalAudioTimeMs(ms);
 
   const nextIndex = chapterList.findIndex((chapter) => {
     return currentMs >= chapter.startMs && currentMs < chapter.endMs;

--- a/template/assets/chapters.js
+++ b/template/assets/chapters.js
@@ -3,6 +3,17 @@ let chapterList = [];
 let currentChapterIndex = -1;
 
 /**
+ * 秒数（小数可）をミリ秒へ変換する
+ * @param {number|string|null|undefined} secondsValue 秒数
+ * @returns {number} ミリ秒
+ */
+function convertSecondsToMs(secondsValue) {
+  const seconds = Number(secondsValue);
+  if (!Number.isFinite(seconds)) return Number.NaN;
+  return seconds * 1000;
+}
+
+/**
  * application/json+chapters 形式のデータからチャプター配列を抽出する
  * @param {object|string} chaptersData チャプターデータ（オブジェクトまたはJSON文字列）
  * @returns {object[]} 正規化したチャプター配列
@@ -20,29 +31,49 @@ function normalizeChapters(chaptersData) {
     }
   }
 
-  const chapters = Array.isArray(parsed)
-    ? parsed
-    : Array.isArray(parsed.chapters)
-      ? parsed.chapters
+  const chapters = Array.isArray(parsed?.chapters)
+    ? parsed.chapters
+    : Array.isArray(parsed)
+      ? parsed
       : [];
 
-  return chapters
+  const normalized = chapters
     .map((chapter, index) => {
-      const startMs = chapter.startMs ?? chapter.start_ms ?? chapter.start ?? chapter.from ?? 0;
-      const endMs = chapter.endMs ?? chapter.end_ms ?? chapter.end ?? chapter.to ?? Number.POSITIVE_INFINITY;
-      const title = chapter.title ?? chapter.name ?? `チャプター ${index + 1}`;
-      const description = chapter.description ?? chapter.text ?? '';
+      const startMs = chapter.startTime !== undefined
+        ? convertSecondsToMs(chapter.startTime)
+        : Number(chapter.startMs ?? chapter.start_ms ?? chapter.start ?? chapter.from ?? Number.NaN);
+
+      const hasEndTime = chapter.endTime !== undefined;
+      const hasLegacyEnd = chapter.endMs !== undefined
+        || chapter.end_ms !== undefined
+        || chapter.end !== undefined
+        || chapter.to !== undefined;
+
+      const endMs = hasEndTime
+        ? convertSecondsToMs(chapter.endTime)
+        : hasLegacyEnd
+          ? Number(chapter.endMs ?? chapter.end_ms ?? chapter.end ?? chapter.to)
+          : Number.NaN;
 
       return {
         index,
-        startMs: Number(startMs),
-        endMs: Number(endMs),
-        title,
-        description
+        startMs,
+        endMs,
+        title: chapter.title ?? chapter.name ?? `チャプター ${index + 1}`,
+        description: chapter.description ?? chapter.text ?? ''
       };
     })
     .filter((chapter) => Number.isFinite(chapter.startMs))
     .sort((a, b) => a.startMs - b.startMs);
+
+  normalized.forEach((chapter, index) => {
+    if (!Number.isFinite(chapter.endMs)) {
+      const nextChapter = normalized[index + 1];
+      chapter.endMs = nextChapter ? nextChapter.startMs : Number.POSITIVE_INFINITY;
+    }
+  });
+
+  return normalized;
 }
 
 /**

--- a/template/assets/chapters.js
+++ b/template/assets/chapters.js
@@ -1,0 +1,116 @@
+let chapterDisplayElement = null;
+let chapterList = [];
+let currentChapterIndex = -1;
+
+/**
+ * application/json+chapters 形式のデータからチャプター配列を抽出する
+ * @param {object|string} chaptersData チャプターデータ（オブジェクトまたはJSON文字列）
+ * @returns {object[]} 正規化したチャプター配列
+ */
+function normalizeChapters(chaptersData) {
+  if (!chaptersData) return [];
+
+  let parsed = chaptersData;
+  if (typeof chaptersData === 'string') {
+    try {
+      parsed = JSON.parse(chaptersData);
+    } catch (error) {
+      console.warn('チャプターデータのJSON解析に失敗しました', error);
+      return [];
+    }
+  }
+
+  const chapters = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(parsed.chapters)
+      ? parsed.chapters
+      : [];
+
+  return chapters
+    .map((chapter, index) => {
+      const startMs = chapter.startMs ?? chapter.start_ms ?? chapter.start ?? chapter.from ?? 0;
+      const endMs = chapter.endMs ?? chapter.end_ms ?? chapter.end ?? chapter.to ?? Number.POSITIVE_INFINITY;
+      const title = chapter.title ?? chapter.name ?? `チャプター ${index + 1}`;
+      const description = chapter.description ?? chapter.text ?? '';
+
+      return {
+        index,
+        startMs: Number(startMs),
+        endMs: Number(endMs),
+        title,
+        description
+      };
+    })
+    .filter((chapter) => Number.isFinite(chapter.startMs))
+    .sort((a, b) => a.startMs - b.startMs);
+}
+
+/**
+ * 画面表示を更新する
+ * @param {object|null} chapter 表示するチャプター
+ */
+function renderChapter(chapter) {
+  if (!chapterDisplayElement) return;
+
+  if (!chapter) {
+    chapterDisplayElement.textContent = '';
+    return;
+  }
+
+  chapterDisplayElement.textContent = chapter.description
+    ? `${chapter.title}：${chapter.description}`
+    : chapter.title;
+}
+
+/**
+ * 指定した再生時刻に一致するチャプターを検索して表示する
+ * @param {number} ms 現在の再生位置（ミリ秒）
+ */
+function updateChapterDisplay(ms) {
+  if (!chapterDisplayElement || chapterList.length === 0) return;
+
+  const currentMs = Number.isFinite(ms) ? ms : (window.__AUDIO2MOVIE_TIME__ || 0);
+
+  const nextIndex = chapterList.findIndex((chapter) => {
+    return currentMs >= chapter.startMs && currentMs < chapter.endMs;
+  });
+
+  if (nextIndex === currentChapterIndex) return;
+
+  currentChapterIndex = nextIndex;
+  renderChapter(nextIndex >= 0 ? chapterList[nextIndex] : null);
+}
+
+/**
+ * チャプター表示を初期化する
+ * @param {string} elementId チャプター表示先要素のID
+ * @param {object|string} chaptersData application/json+chapters 形式のデータ
+ */
+function initChapterDisplay(elementId, chaptersData) {
+  chapterDisplayElement = document.getElementById(elementId);
+  if (!chapterDisplayElement) {
+    console.warn(`チャプター表示先の要素が見つかりません: ${elementId}`);
+    return;
+  }
+
+  chapterList = normalizeChapters(chaptersData);
+  currentChapterIndex = -1;
+  updateChapterDisplay(window.__AUDIO2MOVIE_TIME__ || 0);
+}
+
+window.initChapterDisplay = initChapterDisplay;
+window.updateChapterDisplay = updateChapterDisplay;
+
+/**
+ * 共通の描画エントリーポイントを設定する
+ * 既存のwindow.drawがある場合は先に実行してからチャプター表示を更新する
+ */
+(function setupDrawEntryPoint() {
+  const previousDraw = window.draw;
+  window.draw = function (ms) {
+    if (typeof previousDraw === 'function') {
+      previousDraw(ms);
+    }
+    updateChapterDisplay(ms);
+  };
+})();

--- a/template/neighborhoodengawa/02.html
+++ b/template/neighborhoodengawa/02.html
@@ -28,6 +28,11 @@
     <canvas id="visualizer"></canvas>
   </section>
 
+  <section class="chapter-display">
+    <h2>チャプター</h2>
+    <div id="chapter-display"></div>
+  </section>
+
   <section class="keyword">
     <h2>テーマ</h2>
     <p id="keyword"></p>
@@ -35,6 +40,7 @@
 
   <script src="script.js"></script>
   <script src="../assets/visualizer.js"></script>
+  <script src="../assets/chapters.js"></script>
   <script>
     initVisualizer('visualizer');
   </script>

--- a/template/neighborhoodengawa/script.js
+++ b/template/neighborhoodengawa/script.js
@@ -50,6 +50,7 @@ window.init = function (params) {
     applyWipeInEffect(orgEl, 1000);       // 即時
     applyWipeInEffect(nameEl, 1500);   // 1秒遅延
     applyWipeInEffect(keyEl, 2000);    // 1.5秒遅延
+    initChapterDisplay("chapter-display", params.chapters);
   }
   if (params.photo) {
     let imageUrl;

--- a/template/neighborhoodengawa/style.css
+++ b/template/neighborhoodengawa/style.css
@@ -49,7 +49,8 @@ h1 {
 }
 
 #scene2 .photo h2,
-#scene2 .keyword h2 {
+#scene2 .keyword h2,
+#scene2 .chapter-display h2 {
   display: none;
 }
 
@@ -202,7 +203,7 @@ h1 {
 #scene2 .visualizer,
 #scene3 .visualizer {
   position: absolute;
-  bottom: 160px;
+  bottom: 200px;
   left: 730px;
   background-color: rgba(0, 0, 0, 0.8);
   border-radius: 20px;
@@ -219,6 +220,25 @@ h1 {
   width: 800px;
   height: 250px;
   max-width: 800px;
+}
+
+/* チャプター表示: ビジュアライザーの下に配置 */
+.chapter-display {
+  position: absolute;
+  bottom: 90px;
+  left: 730px;
+  height: 100px;
+  font-size: 24px;
+  color: white;
+  background-color: rgba(0, 0, 0, 0.2);
+  border: 1px solid black;
+  border-radius: 20px;
+  /* ボードの幅 + 余白 */
+  right: 550px;
+  /* キーワードの幅 + 余白 */
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 /* ロゴの出現アニメーション定義 */

--- a/template/sample_chapters/01.html
+++ b/template/sample_chapters/01.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="ja">
+
+<head>
+  <meta charset="utf-8">
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <div class="scene-title">チャプター表示サンプル 01</div>
+  <div id="chapter-display" class="chapter-display"></div>
+
+  <script src="../assets/chapters.js"></script>
+  <script src="script.js"></script>
+  <script>
+    initSampleChapterScene('chapter-display', 0);
+  </script>
+</body>
+
+</html>

--- a/template/sample_chapters/02.html
+++ b/template/sample_chapters/02.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="ja">
+
+<head>
+  <meta charset="utf-8">
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <div class="scene-title">チャプター表示サンプル 02</div>
+  <div id="chapter-display" class="chapter-display"></div>
+
+  <script src="../assets/chapters.js"></script>
+  <script src="script.js"></script>
+  <script>
+    initSampleChapterScene('chapter-display', 4);
+  </script>
+</body>
+
+</html>

--- a/template/sample_chapters/03.html
+++ b/template/sample_chapters/03.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="ja">
+
+<head>
+  <meta charset="utf-8">
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <div class="scene-title">チャプター表示サンプル 03</div>
+  <div id="chapter-display" class="chapter-display"></div>
+
+  <script src="../assets/chapters.js"></script>
+  <script src="script.js"></script>
+  <script>
+    initSampleChapterScene('chapter-display', 8);
+  </script>
+</body>
+
+</html>

--- a/template/sample_chapters/scenario.json
+++ b/template/sample_chapters/scenario.json
@@ -1,0 +1,28 @@
+{
+  "scenes": [
+    {
+      "html": "01.html",
+      "duration": 4,
+      "transition": {
+        "name": "fade",
+        "duration": 1
+      }
+    },
+    {
+      "html": "02.html",
+      "duration": "rem",
+      "transition": {
+        "name": "wipeleft",
+        "duration": 1
+      }
+    },
+    {
+      "html": "03.html",
+      "duration": 4,
+      "transition": {
+        "name": "fade",
+        "duration": 1
+      }
+    }
+  ]
+}

--- a/template/sample_chapters/script.js
+++ b/template/sample_chapters/script.js
@@ -1,0 +1,52 @@
+/**
+ * チャプター表示の動作確認に使うサンプルデータ
+ * application/json+chapters 形式を想定
+ */
+const sampleChapters = {
+  chapters: [
+    {
+      startMs: 0,
+      endMs: 2500,
+      title: '導入',
+      description: '番組のテーマを紹介します'
+    },
+    {
+      startMs: 2500,
+      endMs: 5500,
+      title: '前半',
+      description: '前半のトークパートです'
+    },
+    {
+      startMs: 5500,
+      endMs: 9000,
+      title: '中盤',
+      description: '核心となる内容を説明します'
+    },
+    {
+      startMs: 9000,
+      endMs: 13000,
+      title: '後半',
+      description: 'まとめに向けて話を展開します'
+    },
+    {
+      startMs: 13000,
+      endMs: 999999,
+      title: '締め',
+      description: 'エンディングです'
+    }
+  ]
+};
+
+/**
+ * サンプルシーンの初期化を行う
+ * @param {string} elementId 表示先要素のID
+ * @param {number} startSeconds シーン開始オフセット秒
+ */
+function initSampleChapterScene(elementId, startSeconds) {
+  const titleElement = document.querySelector('.scene-title');
+  if (titleElement) {
+    titleElement.textContent += `（開始 ${startSeconds.toFixed(1)}秒）`;
+  }
+
+  initChapterDisplay(elementId, sampleChapters);
+}

--- a/template/sample_chapters/script.js
+++ b/template/sample_chapters/script.js
@@ -3,36 +3,26 @@
  * application/json+chapters 形式を想定
  */
 const sampleChapters = {
+  version: '1.2.0',
   chapters: [
     {
-      startMs: 0,
-      endMs: 2500,
-      title: '導入',
-      description: '番組のテーマを紹介します'
+      startTime: '0.0',
+      endTime: '2.5',
+      title: '導入'
     },
     {
-      startMs: 2500,
-      endMs: 5500,
-      title: '前半',
-      description: '前半のトークパートです'
+      startTime: '2.5',
+      endTime: '5.5',
+      title: '前半'
     },
     {
-      startMs: 5500,
-      endMs: 9000,
-      title: '中盤',
-      description: '核心となる内容を説明します'
+      startTime: '5.5',
+      endTime: '9.0',
+      title: '中盤'
     },
     {
-      startMs: 9000,
-      endMs: 13000,
-      title: '後半',
-      description: 'まとめに向けて話を展開します'
-    },
-    {
-      startMs: 13000,
-      endMs: 999999,
-      title: '締め',
-      description: 'エンディングです'
+      startTime: '9.0',
+      title: '締め'
     }
   ]
 };

--- a/template/sample_chapters/style.css
+++ b/template/sample_chapters/style.css
@@ -1,0 +1,33 @@
+html,
+body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+  background: linear-gradient(135deg, #0f172a, #1e293b);
+  color: #e2e8f0;
+  font-family: sans-serif;
+}
+
+.scene-title {
+  position: absolute;
+  top: 80px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 64px;
+  font-weight: 700;
+}
+
+.chapter-display {
+  position: absolute;
+  left: 50%;
+  bottom: 160px;
+  transform: translateX(-50%);
+  min-width: 60%;
+  padding: 24px 32px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  font-size: 48px;
+  text-align: center;
+}


### PR DESCRIPTION
### Motivation
- Provide in-page chapter display from `application/json+chapters` formatted data and ensure it updates with the existing `window.draw` render loop. 
- Include runnable sample scenes to demonstrate behavior and make it easy to manually verify chapter rendering and styling.

### Description
- Added `template/assets/chapters.js` which implements `normalizeChapters`, `renderChapter`, `updateChapterDisplay`, `initChapterDisplay`, exposes `window.initChapterDisplay`/`window.updateChapterDisplay`, and wraps `window.draw` to invoke chapter updates. 
- Added `template/sample_chapters` including `01.html`, `02.html`, `03.html`, `scenario.json`, `script.js` (providing `sampleChapters` and `initSampleChapterScene`), and `style.css` to showcase the chapter display UI. 
- Normalization supports multiple timestamp property names (`startMs`, `start_ms`, `start`, `from`, etc.), sorts chapters by start time, and tolerates JSON strings or objects.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06fd0166ac8322a94b36e7624f6709)